### PR TITLE
Remove duplicate attr_readers

### DIFF
--- a/lib/nutrition_facts/item.rb
+++ b/lib/nutrition_facts/item.rb
@@ -5,8 +5,7 @@ class NutritionFacts::Item
                 :nf_protein, :nf_serving_size_qty, :nf_serving_size_unit,
                 :nf_serving_weight_grams, :nf_sodium, :nf_vitamin_c_dv,
                 :nf_vitamin_a_dv, :nf_calories_from_fat, :nf_saturated_fat,
-                :nf_cholesterol, :nf_calcium_dv, :nf_iron_dv,
-                :nf_serving_size_qty, :nf_serving_size_unit
+                :nf_cholesterol, :nf_calcium_dv, :nf_iron_dv
 
   def initialize(item_list = {})
     item_list.each do |key, value|


### PR DESCRIPTION
Neat library, served well as an introduction to some of the Nutritionix API.

Accessors for `:nf_serving_size_qty` and `:nf_serving_size_unit` are duplicated on line 5.